### PR TITLE
MonoでもREPLを動かせるようにする

### DIFF
--- a/SLCImplementation/Makefile
+++ b/SLCImplementation/Makefile
@@ -1,0 +1,26 @@
+FSC = /usr/local/bin/fsharpc
+FSCFLAGS = --debug:full --debug+
+FSFILES =	\
+    common.fs	\
+    lexer.fs	\
+    parser.fs	\
+    form.fs	\
+    preparse.fs	\
+    slc.fs	\
+    parse.fs	\
+    unify.fs	\
+    typesys.fs	\
+    slctype.fs	\
+    cbveval.fs	\
+    slcint.fs	\
+    toplev.fs	\
+    Program.fs
+TARGET = slc.exe
+
+.PHONY: clean
+
+$(TARGET): $(FSFILES)
+	$(FSC) $(FSCFLAGS) $(FSFILES) -o:$(TARGET)
+
+clean:
+	rm -f $(TARGET) $(TARGET).mdb

--- a/SLCImplementation/Program.fs
+++ b/SLCImplementation/Program.fs
@@ -16,17 +16,19 @@ let rec repl () =
     printf "SLC> "
     let line =
       Console.ReadLine()
-      |> function null -> "quit" | l -> l.Trim()
+      |> function null -> "#quit" | l -> l.Trim()
     match line with
-    | "quit" -> ()
-    | "help" | "" ->
+    | "#quit" -> printfn "Exit..."
+    | "#help" | "" ->
         printfn "Usage:"
-        printfn "    >expression"
-        printfn "        evaluate expression"
-        printfn "    >name := expression"
-        printfn "        evaluate expression and define it"
-        printfn "    >quit"
-        printfn "        quit repl"
+        printfn "> expression"
+        printfn "    evaluate expression"
+        printfn "> name := expression"
+        printfn "    evaluate expression and define it"
+        printfn "> #quit"
+        printfn "    quit repl"
+        printfn "> #help"
+        printfn "    show this usage"
         repl ()
     | s ->
         try
@@ -35,7 +37,7 @@ let rec repl () =
             | Eval e -> printfn "%s" (z_to_str e)
         with ex ->
             printfn "Error: %s" ex.Message
-            printfn "show usage: >help"
+            printfn "#help for usage"
         repl ()
 
 

--- a/SLCImplementation/Program.fs
+++ b/SLCImplementation/Program.fs
@@ -1,11 +1,15 @@
-﻿[<FunScript.JS>]
+﻿#if TOJS
+[<FunScript.JS>]
+#endif
 module Program
 open System
 open form
 open preparse
 open toplev
+#if TOJS
 open FunScript
 open FunScript.TypeScript
+#endif
 
 //REPL
 let rec repl () =
@@ -33,7 +37,7 @@ let rec repl () =
 
 
 
-
+#if TOJS
 //JSFFI
 [<JSEmit("return createOutputCard({0}, {1}, {2}, {3})")>]
 let createOutputCard (code: string) (output: string) (error: bool) (name: string): 'TAny = failwith "never"
@@ -46,7 +50,6 @@ let submit s =
     with ex ->
         createOutputCard s ("Error: " + ex.ToString()) true ""
 
-#if TOJS
 [<EntryPoint>]
 let main args =
     let sw = new IO.StreamWriter(@"..\..\..\Try-SLC\js\slc.js")

--- a/SLCImplementation/Program.fs
+++ b/SLCImplementation/Program.fs
@@ -13,7 +13,7 @@ open FunScript.TypeScript
 
 //REPL
 let rec repl () =
-    printf ">"
+    printf "SLC> "
     let line =
       Console.ReadLine()
       |> function null -> "quit" | l -> l.Trim()

--- a/SLCImplementation/Program.fs
+++ b/SLCImplementation/Program.fs
@@ -14,7 +14,10 @@ open FunScript.TypeScript
 //REPL
 let rec repl () =
     printf ">"
-    match Console.ReadLine().Trim() with
+    let line =
+      Console.ReadLine()
+      |> function null -> "quit" | l -> l.Trim()
+    match line with
     | "quit" -> ()
     | "help" | "" ->
         printfn "Usage:"

--- a/SLCImplementation/cbveval.fs
+++ b/SLCImplementation/cbveval.fs
@@ -1,5 +1,7 @@
 ﻿//semantic domains for CBV evaluation (p.112)
+#if TOJS
 [<FunScript.JS>]
+#endif
 module cbveval
 open slc
 open typesys

--- a/SLCImplementation/form.fs
+++ b/SLCImplementation/form.fs
@@ -1,5 +1,7 @@
 ﻿//syntactic forms recognized by the YACC pre-parser (pp.103-104)
+#if TOJS
 [<FunScript.JS>]
+#endif
 module form
 
 type form =

--- a/SLCImplementation/lexer.fs
+++ b/SLCImplementation/lexer.fs
@@ -1,4 +1,6 @@
+#if TOJS
 [<FunScript.JS>]
+#endif
 module lexer
 open System.Text.RegularExpressions
 

--- a/SLCImplementation/parse.fs
+++ b/SLCImplementation/parse.fs
@@ -1,5 +1,7 @@
 ﻿//parser for SLC terms (CBV recursion) (pp.104-106)
+#if TOJS
 [<FunScript.JS>]
+#endif
 module parse
 
 open form

--- a/SLCImplementation/parser.fs
+++ b/SLCImplementation/parser.fs
@@ -1,4 +1,6 @@
-﻿[<FunScript.JS>]
+﻿#if TOJS
+[<FunScript.JS>]
+#endif
 module parser
 open common
 

--- a/SLCImplementation/preparse.fs
+++ b/SLCImplementation/preparse.fs
@@ -1,4 +1,6 @@
-﻿[<FunScript.JS>]
+﻿#if TOJS
+[<FunScript.JS>]
+#endif
 module preparse
 open lexer
 open parser
@@ -13,7 +15,9 @@ type token =
     | NUM of int
     | EOF
 
+#if TOJS
 [<FunScript.JSEmit("return Number({0})")>]
+#endif
 let number x = failwith "never"
 
 let patterns = [|

--- a/SLCImplementation/slc.fs
+++ b/SLCImplementation/slc.fs
@@ -1,5 +1,7 @@
 ﻿//abstract syntax of the SLC (p.106)
+#if TOJS
 [<FunScript.JS>]
+#endif
 module slc
 
 type var = string

--- a/SLCImplementation/slcint.fs
+++ b/SLCImplementation/slcint.fs
@@ -1,5 +1,7 @@
 ﻿//CBV interpreter for SLC terms (pp.112-113)
+#if TOJS
 [<FunScript.JS>]
+#endif
 module slcint
 open slc
 open cbveval

--- a/SLCImplementation/slctype.fs
+++ b/SLCImplementation/slctype.fs
@@ -1,5 +1,7 @@
 ﻿//type inferencer for SLC terms (pp.109-110)
+#if TOJS
 [<FunScript.JS>]
+#endif
 module slctype
 open common
 open slc

--- a/SLCImplementation/toplev.fs
+++ b/SLCImplementation/toplev.fs
@@ -1,5 +1,7 @@
 ﻿//top level interaction (pp.114-115)
+#if TOJS
 [<FunScript.JS>]
+#endif
 module toplev
 open parse
 open typesys

--- a/SLCImplementation/typesys.fs
+++ b/SLCImplementation/typesys.fs
@@ -1,5 +1,7 @@
 ﻿//SLC/SCL type system (pp.109-110)
+#if TOJS
 [<FunScript.JS>]
+#endif
 module typesys
 open unify
 

--- a/SLCImplementation/unify.fs
+++ b/SLCImplementation/unify.fs
@@ -1,5 +1,7 @@
 ﻿//unification and resolution theorem prover (pp.108-109)
+#if TOJS
 [<FunScript.JS>]
+#endif
 module unify
 open common
 


### PR DESCRIPTION
非Windows環境でもMonoでREPLが動かせるようにしてみました。

変更点は↓のような感じです。
- FunScript に関係するところを `#if TOJS` 〜 `#endif` で囲む
- Makefile を追加（xbuild がよくわかりませんでした）

おまけで、REPLを使っていて気になったところも変更しています。
- REPL で Ctrl-D したら quit の意味になるように（NullReferenceExeption で落ちないように）
- quit や help という名前の変数を参照できるように（終了は #quit、ヘルプは #help を使う）
- SLC だとわかるようなプロンプトを出す
