### PR TITLE
MonoでもREPLを動かせるようにする

### DIFF
--- a/SLCImplementation/Makefile
+++ b/SLCImplementation/Makefile
@@ -1,0 +1,25 @@
+FSC = /usr/local/bin/fsharpc
+FSCFLAGS = --debug:full --debug+
+FSFILES =	\
+    lexer.fs	\
+    parser.fs	\
+    form.fs	\
+    preparse.fs	\
+    slc.fs	\
+    parse.fs	\
+    unify.fs	\
+    typesys.fs	\
+    slctype.fs	\
+    cbveval.fs	\
+    slcint.fs	\
+    toplev.fs	\
+    Program.fs
+TARGET = slc.exe
+
+.PHONY: clean
+
+$(TARGET): $(FSFILES)
+	$(FSC) $(FSCFLAGS) $(FSFILES) -o:$(TARGET)
+
+clean:
+	rm -f $(TARGET) $(TARGET).mdb

--- a/SLCImplementation/Program.fs
+++ b/SLCImplementation/Program.fs
@@ -7,7 +7,10 @@ open toplev
 //REPL
 let rec repl () =
     printf ">"
-    match Console.ReadLine().Trim() with
+    let line =
+      Console.ReadLine()
+      |> function null -> "quit" | l -> l.Trim()
+    match line with
     | "quit" -> ()
     | "help" | "" ->
         printfn "Usage:"

--- a/SLCImplementation/Program.fs
+++ b/SLCImplementation/Program.fs
@@ -6,20 +6,22 @@ open toplev
 
 //REPL
 let rec repl () =
-    printf ">"
+    printf "> "
     let line =
       Console.ReadLine()
-      |> function null -> "quit" | l -> l.Trim()
+      |> function null -> ":quit" | l -> l.Trim()
     match line with
-    | "quit" -> ()
-    | "help" | "" ->
+    | ":quit" -> printfn "Exit..."
+    | ":help" | "" ->
         printfn "Usage:"
-        printfn "    >expression"
-        printfn "        evaluate expression"
-        printfn "    >name := expression"
-        printfn "        evaluate expression and define it"
-        printfn "    >quit"
-        printfn "        quit repl"
+        printfn "> expression"
+        printfn "    evaluate expression"
+        printfn "> name := expression"
+        printfn "    evaluate expression and define it"
+        printfn "> :quit"
+        printfn "    quit repl"
+        printfn "> :help"
+        printfn "    show this usage"
         repl ()
     | s ->
         try
@@ -28,7 +30,7 @@ let rec repl () =
             | Eval e -> printfn "%s" (z_to_str e)
         with ex ->
             printfn "Error: %s" ex.Message
-            printfn "show usage: >help"
+            printfn ":help for usage"
         repl ()
 
 [<EntryPoint>]


### PR DESCRIPTION
https://github.com/koropicot/SLC-Implementation/pull/1 をmaster へのPRに変更しました。

変更点は以下の通りです。
- MonoでビルドするためのMakefileを追加
- Ctrl-D でNullReferenceExceptionを投げず終了するように
- コマンドを :quit や :help に変更（quit や help という式をREPLで受け付けるように）
